### PR TITLE
(maint) Add missing module file

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,0 +1,8 @@
+name    'BenoitCattie-nginx'
+version '0.0.2'
+source 'https://github.com/BenoitCattie/puppet-nginx.git'
+author 'BenoitCattie'
+license 'APACHE2'
+summary 'Basic module for configuring nginx via puppet'
+description 'Basic module for configuring nginx via puppet. You can easily create fcgi vhost with this module.'
+project_page 'http://github.com/BenoitCattie/puppet-nginx'


### PR DESCRIPTION
Before this commit the Modulefile was missing. As a result the
puppet-module tool was not able to download this module from the Puppet
Forge.

This patch solves this issue my adding the missing Modulefile.
