### PR TITLE
(maint) Puppet style guide improvements

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,27 @@
+# Define: nginx::config
+#
+# Define a nginx config snippet. Places all config snippets into
+# /etc/nginx/conf.d, where they will be automatically loaded by http module
+#
+#
+# Parameters :
+# * ensure: typically set to "present" or "absent". Defaults to "present"
+# * content: set the content of the config snipppet. Defaults to 'template("nginx/${name}.conf.erb")'
+# * order: specifies the load order for this config snippet. Defaults to "500"
+#
+define nginx::config($ensure='present', $content=undef, $order='500') {
+  $real_content = $content ? {
+    undef   => template("nginx/${name}.conf.erb"),
+    default => $content,
+  }
+
+  file { "${nginx::nginx_conf}/${order}-${name}.conf":
+    ensure  => $ensure,
+    content => $real_content,
+    mode    => '0644',
+    owner   => 'root',
+    group   => 'root',
+    notify  => Exec['reload-nginx'],
+  }
+}
+

--- a/manifests/fcgi.pp
+++ b/manifests/fcgi.pp
@@ -1,87 +1,13 @@
 # Class: nginx::fcgi
 #
 # Manage nginx fcgi configuration.
-# Provide nginx::fcgi::site 
+# Provide nginx::fcgi::site
 #
 # Templates :
-#	* nginx/includes/fastcgi_params.erb
+# * nginx/includes/fastcgi_params.erb
 #
 class nginx::fcgi inherits nginx {
-
-	nginx::site_include{"fastcgi_params": 
-		content => template("nginx/includes/fastcgi_params.erb"),
-	}
-
-	# Define: nginx::fcgi::site
-	#
-	# Create a fcgi site config from template using parameters.
-	# You can use my php5-fpm class to manage fastcgi servers.
-	#
-	# Parameters :
-	# 	* ensure: typically set to "present" or "absent". Defaults to "present"
-	# 	* root: document root (Required)
-	#	* fastcgi_pass : port or socket on which the FastCGI-server is listening (Required)
-	#	* server_name : server_name directive (could be an array)
-	#	* listen : address/port the server listen to. Defaults to 80. Auto enable ssl if 443
-	#	* access_log : custom acces logs. Defaults to /var/log/nginx/$name_access.log
-	#	* include : custom include for the site (could be an array). Include files must exists 
-	#	   to avoid nginx reload errors. Use with nginx::site_include  
-	#	* ssl_certificate : ssl_certificate path. If empty auto-generating ssl cert
-	#	* ssl_certificate_key : ssl_certificate_key path. If empty auto-generating ssl cert key
-	#   See http://wiki.nginx.org for details.
-	#
-	# Templates :
-	#	* nginx/fcgi_site.erb
-	#
-	# Sample Usage :
-	#         nginx::fcgi::site {"default":
-	#                 root            => "/var/www/nginx-default",
-	#                 fastcgi_pass    => "127.0.0.1:9000",
-	#                 server_name     => ["localhost", "$hostname", "$fqdn"],
-	#          }
-	#
-	#         nginx::fcgi::site {"default-ssl":
-	#                 listen          => "443",
-	#                 root            => "/var/www/nginx-default",
-	#                 fastcgi_pass    => "127.0.0.1:9000",
-	#                 server_name     => "$fqdn",
-	#          }
-	define site ( $ensure = 'present', $index = 'index.php', $root, $fastcgi_pass, $include = '', $listen = '80', $server_name = '', $access_log = '', $ssl_certificate = '', $ssl_certificate_key = '', $ssl_session_timeout = '5m') { 
-
-		$real_server_name = $server_name ? { 
-			'' => "${name}",
-            		default => $server_name,
-          	}
-
-		$real_access_log = $access_log ? { 
-			'' => "/var/log/nginx/${name}_access.log",
-            		default => $access_log,
-          	}
-
-		#Autogenerating ssl certs
-		if $listen == '443' and  $ensure == 'present' and ( $ssl_certificate == '' or $ssl_certificate_key == '') {
-			exec {"generate-${name}-certs":
-				command => "/usr/bin/openssl req -new -inform PEM -x509 -nodes -days 999 -subj '/C=ZZ/ST=AutoSign/O=AutoSign/localityName=AutoSign/commonName=${real_server_name}/organizationalUnitName=AutoSign/emailAddress=AutoSign/' -newkey rsa:2048 -out /etc/nginx/ssl/${name}.pem -keyout /etc/nginx/ssl/${name}.key",
-				unless	=> "/usr/bin/test -f /etc/nginx/ssl/${name}.pem",
-				require	=> File["/etc/nginx/ssl"],
-				notify	=> Exec["reload-nginx"],
-			}
-		}
-
-		$real_ssl_certificate = $ssl_certificate ? { 
-			'' => "/etc/nginx/ssl/${name}.pem",
-            		default => $ssl_certificate,
-          	}
-		$real_ssl_certificate_key = $ssl_certificate_key ? { 
-			'' => "/etc/nginx/ssl/${name}.key",
-            		default => $ssl_certificate_key,
-          	}
-
-		nginx::site {"${name}":
-			ensure	=> $ensure,
-			content	=> template("nginx/fcgi_site.erb"),
-		}
-		
-	}
-
+  nginx::site_include { 'fastcgi_params':
+    content => template('nginx/includes/fastcgi_params.erb'),
+  }
 }

--- a/manifests/fcgi/site.pp
+++ b/manifests/fcgi/site.pp
@@ -1,0 +1,86 @@
+# Define: nginx::fcgi::site
+#
+# Create a fcgi site config from template using parameters.
+# You can use my php5-fpm class to manage fastcgi servers.
+#
+# Parameters :
+# * ensure: typically set to "present" or "absent". Defaults to "present"
+# * root: document root (Required)
+# * fastcgi_pass : port or socket on which the FastCGI-server is listening (Required)
+# * server_name : server_name directive (could be an array)
+# * listen : address/port the server listen to. Defaults to 80. Auto enable ssl if 443
+# * access_log : custom acces logs. Defaults to /var/log/nginx/$name_access.log
+# * include : custom include for the site (could be an array). Include files must exists
+#   to avoid nginx reload errors. Use with nginx::site_include
+# * ssl_certificate : ssl_certificate path. If empty auto-generating ssl cert
+# * ssl_certificate_key : ssl_certificate_key path. If empty auto-generating ssl cert key
+#   See http://wiki.nginx.org for details.
+#
+# Templates :
+# * nginx/fcgi_site.erb
+#
+# Sample Usage :
+#   nginx::fcgi::site { 'default':
+#     root         => '/var/www/nginx-default',
+#     fastcgi_pass => '127.0.0.1:9000',
+#     server_name  => ['localhost', $hostname, $fqdn],
+#   }
+#
+#   nginx::fcgi::site { 'default-ssl':
+#     listen          => '443',
+#     root            => '/var/www/nginx-default',
+#     fastcgi_pass    => '127.0.0.1:9000',
+#     server_name     => $fqdn,
+#   }
+#
+define nginx::fcgi::site(
+  $root,
+  $fastcgi_pass,
+  $ensure              = 'present',
+  $index               = 'index.php',
+  $include             = '',
+  $listen              = '80',
+  $server_name         = undef,
+  $access_log          = undef,
+  $ssl_certificate     = undef,
+  $ssl_certificate_key = undef,
+  $ssl_session_timeout = '5m') {
+
+  $real_server_name = $server_name ? {
+    undef   => $name,
+    default => $server_name,
+  }
+
+  $real_access_log = $access_log ? {
+    undef   => "/var/log/nginx/${name}_access.log",
+    default => $access_log,
+  }
+
+  # Autogenerating ssl certs
+  if $listen == '443' and  $ensure == 'present' and ($ssl_certificate == undef or $ssl_certificate_key == undef) {
+    exec { "generate-${name}-certs":
+      command => "/usr/bin/openssl req -new -inform PEM -x509 -nodes -days 999 -subj \
+        '/C=ZZ/ST=AutoSign/O=AutoSign/localityName=AutoSign/commonName=${real_server_name}/organizationalUnitName=AutoSign/emailAddress=AutoSign/' \
+        -newkey rsa:2048 -out /etc/nginx/ssl/${name}.pem -keyout /etc/nginx/ssl/${name}.key",
+      unless  => "/usr/bin/test -f /etc/nginx/ssl/${name}.pem",
+      require => File['/etc/nginx/ssl'],
+      notify  => Exec['reload-nginx'],
+    }
+  }
+
+  $real_ssl_certificate = $ssl_certificate ? {
+    undef   => "/etc/nginx/ssl/${name}.pem",
+    default => $ssl_certificate,
+  }
+
+  $real_ssl_certificate_key = $ssl_certificate_key ? {
+    undef   => "/etc/nginx/ssl/${name}.key",
+    default => $ssl_certificate_key,
+  }
+
+  nginx::site { $name:
+    ensure  => $ensure,
+    content => template('nginx/fcgi_site.erb'),
+  }
+}
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,22 +23,22 @@ class nginx {
   $nginx_includes = '/etc/nginx/includes'
   $nginx_conf = '/etc/nginx/conf.d'
 
-  $real_nginx_user = $nginx_user ? {
-    ''      => 'www-data',
-    default => $nginx_user
+  $real_nginx_user = $::nginx_user ? {
+    undef   => 'www-data',
+    default => $::nginx_user
   }
 
-  $real_nginx_worker_processes = $nginx_worker_processes ? {
-    ''      => '1',
-    default => $nginx_worker_processes
+  $real_nginx_worker_processes = $::nginx_worker_processes ? {
+    undef   => '1',
+    default => $::nginx_worker_processes
   }
 
-  $real_nginx_worker_connections = $nginx_worker_connections ? {
-    ''      => '1024',
-    default => $nginx_worker_connections
+  $real_nginx_worker_connections = $::nginx_worker_connections ? {
+    undef   => '1024',
+    default => $::nginx_worker_connections
   }
 
-  if ! defined(Package['nginx']) { package { nginx: ensure => installed }}
+  if ! defined(Package['nginx']) { package { 'nginx': ensure => installed }}
 
   service { 'nginx':
     ensure     => running,
@@ -90,122 +90,5 @@ class nginx {
   exec { 'reload-nginx':
     command     => '/etc/init.d/nginx reload',
     refreshonly => true,
-  }
-
-  # Define: nginx::config
-  #
-  # Define a nginx config snippet. Places all config snippets into
-  # /etc/nginx/conf.d, where they will be automatically loaded by http module
-  #
-  #
-  # Parameters :
-  # * ensure: typically set to "present" or "absent". Defaults to "present"
-  # * content: set the content of the config snipppet. Defaults to 'template("nginx/${name}.conf.erb")'
-  # * order: specifies the load order for this config snippet. Defaults to "500"
-  #
-  define config ($ensure='present', $content='', $order='500') {
-    $real_content = $content ? {
-      ''      => template("nginx/${name}.conf.erb"),
-      default => $content,
-    }
-
-    file { "${nginx_conf}/${order}-${name}.conf":
-      ensure  => $ensure,
-      content => $real_content,
-      mode    => '0644',
-      owner   => 'root',
-      group   => 'root',
-      notify  => Exec['reload-nginx'],
-    }
-  }
-
-  # Define: nginx::site
-  #
-  # Install a nginx site in /etc/nginx/sites-available (and symlink in /etc/nginx/sites-enabled).
-  #
-  #
-  # Parameters :
-  # * ensure: typically set to "present" or "absent". Defaults to "present"
-  # * content: site definition (should be a template).
-  #
-  define site ($ensure = 'present', $content = '') {
-    case $ensure {
-      'present' : {
-        nginx::install_site { $name:
-          content => $content
-        }
-      }
-      'absent' : {
-        exec { "rm -f /etc/nginx/sites-enabled/$name":
-          onlyif  => "/bin/sh -c '[ -L /etc/nginx/sites-enabled/$name ] \\
-            && [ /etc/nginx/sites-enabled/$name -ef /etc/nginx/sites-available/$name ]'",
-          notify  => Exec['reload-nginx'],
-          require => Package['nginx'],
-        }
-      }
-      default: { err ( "Unknown ensure value: '$ensure'" ) }
-    }
-  }
-
-  # Define: install_site
-  #
-  # Install nginx vhost
-  # This definition is private, not intended to be called directly
-  #
-  define install_site ($content = '' ) {
-    # first, make sure the site config exists
-    case $content {
-      '': {
-        file { "/etc/nginx/sites-available/${name}":
-          ensure  => present,
-          mode    => '0644',
-          owner   => 'root',
-          group   => 'root',
-          alias   => "sites-$name",
-          notify  => Exec['reload-nginx'],
-          require => Package['nginx'],
-        }
-      }
-      default: {
-        file { "/etc/nginx/sites-available/${name}":
-          ensure  => present,
-          mode    => '0644',
-          owner   => 'root',
-          group   => 'root',
-          alias   => "sites-$name",
-          content => $content,
-          require => Package['nginx'],
-          notify  => Exec['reload-nginx'],
-        }
-      }
-    }
-
-    # now, enable it.
-    exec { "ln -s /etc/nginx/sites-available/${name} /etc/nginx/sites-enabled/${name}":
-      unless  => "/bin/sh -c '[ -L /etc/nginx/sites-enabled/$name ] && [ /etc/nginx/sites-enabled/$name -ef /etc/nginx/sites-available/$name ]'",
-      path    => ['/usr/bin/'],
-      notify  => Exec['reload-nginx'],
-      require => File["sites-$name"],
-    }
-  }
-
-  # Define: site_include
-  #
-  # Define a site config include in /etc/nginx/includes
-  #
-  # Parameters :
-  # * ensure: typically set to "present" or "absent". Defaults to "present"
-  # * content: include definition (should be a template).
-  #
-  define site_include ($ensure='present', $content='') {
-    file { "${nginx_includes}/${name}.inc":
-      ensure  => $ensure,
-      mode    => '0644',
-      owner   => 'root',
-      group   => 'root',
-      content => $content,
-      require => File[$nginx_includes],
-      notify  => Exec['reload-nginx'],
-    }
   }
 }

--- a/manifests/install_site.pp
+++ b/manifests/install_site.pp
@@ -1,0 +1,42 @@
+# Define: install_site
+#
+# Install nginx vhost
+# This definition is private, not intended to be called directly
+#
+define nginx::install_site($content=undef) {
+  # first, make sure the site config exists
+  case $content {
+    undef: {
+      file { "/etc/nginx/sites-available/${name}":
+        ensure  => present,
+        mode    => '0644',
+        owner   => 'root',
+        group   => 'root',
+        alias   => "sites-${name}",
+        notify  => Exec['reload-nginx'],
+        require => Package['nginx'],
+      }
+    }
+    default: {
+      file { "/etc/nginx/sites-available/${name}":
+        ensure  => present,
+        mode    => '0644',
+        owner   => 'root',
+        group   => 'root',
+        alias   => "sites-$name",
+        content => $content,
+        require => Package['nginx'],
+        notify  => Exec['reload-nginx'],
+      }
+    }
+  }
+
+  # now, enable it.
+  exec { "ln -s /etc/nginx/sites-available/${name} /etc/nginx/sites-enabled/${name}":
+    unless  => "/bin/sh -c '[ -L /etc/nginx/sites-enabled/${name} ] && \
+      [ /etc/nginx/sites-enabled/${name} -ef /etc/nginx/sites-available/${name} ]'",
+    path    => ['/usr/bin/', '/bin/'],
+    notify  => Exec['reload-nginx'],
+    require => File["sites-${name}"],
+  }
+}

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -1,0 +1,27 @@
+# Define: nginx::site
+#
+# Install a nginx site in /etc/nginx/sites-available (and symlink in /etc/nginx/sites-enabled).
+#
+#
+# Parameters :
+# * ensure: typically set to "present" or "absent". Defaults to "present"
+# * content: site definition (should be a template).
+#
+define nginx::site($ensure='present', $content='') {
+  case $ensure {
+    'present' : {
+      nginx::install_site { $name:
+        content => $content
+      }
+    }
+    'absent' : {
+      exec { "/bin/rm -f /etc/nginx/sites-enabled/${name}":
+        onlyif  => "/bin/sh -c '[ -L /etc/nginx/sites-enabled/${name} ] && \
+          [ /etc/nginx/sites-enabled/$name -ef /etc/nginx/sites-available/${name} ]'",
+        notify  => Exec['reload-nginx'],
+        require => Package['nginx'],
+      }
+    }
+    default: { err ("Unknown ensure value: '$ensure'") }
+  }
+}

--- a/manifests/site_include.pp
+++ b/manifests/site_include.pp
@@ -1,0 +1,20 @@
+# Define: site_include
+#
+# Define a site config include in /etc/nginx/includes
+#
+# Parameters :
+# * ensure: typically set to "present" or "absent". Defaults to "present"
+# * content: include definition (should be a template).
+#
+define nginx::site_include($ensure='present', $content='') {
+  file { "${nginx::nginx_includes}/${name}.inc":
+    ensure  => $ensure,
+    mode    => '0644',
+    owner   => 'root',
+    group   => 'root',
+    content => $content,
+    require => File[$nginx::nginx_includes],
+    notify  => Exec['reload-nginx'],
+  }
+}
+


### PR DESCRIPTION
Before this patch, defined resources do not live in their own manifests
which is a violation of the Puppet style guide.

This patch resolves this issue by moving all defined resources to their
own Puppet manifests.

This patch also resolves issue #5: Bad path for 'ln' command by updating
the exec resource to include `/bin` to the list of paths.
