### PR TITLE
Removes Exec['reload-nginx'], because Service['nginx'] can also do the thing.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -21,7 +21,7 @@ define nginx::config($ensure='present', $content=undef, $order='500') {
     mode    => '0644',
     owner   => 'root',
     group   => 'root',
-    notify  => Exec['reload-nginx'],
+    notify  => Service['nginx'],
   }
 }
 

--- a/manifests/fcgi/site.pp
+++ b/manifests/fcgi/site.pp
@@ -64,7 +64,7 @@ define nginx::fcgi::site(
         -newkey rsa:2048 -out /etc/nginx/ssl/${name}.pem -keyout /etc/nginx/ssl/${name}.key",
       unless  => "/usr/bin/test -f /etc/nginx/ssl/${name}.pem",
       require => File['/etc/nginx/ssl'],
-      notify  => Exec['reload-nginx'],
+      notify  => Service['nginx'],
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,11 +40,13 @@ class nginx {
 
   if ! defined(Package['nginx']) { package { 'nginx': ensure => installed }}
 
+  #restart-command is a quick-fix here, until http://projects.puppetlabs.com/issues/1014 is solved
   service { 'nginx':
     ensure     => running,
     enable     => true,
     hasrestart => true,
     require    => File['/etc/nginx/nginx.conf'],
+    restart    => '/etc/init.d/nginx reload'
   }
 
   file { '/etc/nginx/nginx.conf':
@@ -53,7 +55,7 @@ class nginx {
     owner   => 'root',
     group   => 'root',
     content => template('nginx/nginx.conf.erb'),
-    notify  => Exec['reload-nginx'],
+    notify  => Service['nginx'],
     require => Package['nginx'],
   }
 
@@ -85,10 +87,5 @@ class nginx {
   file { '/etc/nginx/fastcgi_params':
     ensure  => absent,
     require => Package['nginx'],
-  }
-
-  exec { 'reload-nginx':
-    command     => '/etc/init.d/nginx reload',
-    refreshonly => true,
   }
 }

--- a/manifests/install_site.pp
+++ b/manifests/install_site.pp
@@ -13,7 +13,7 @@ define nginx::install_site($content=undef) {
         owner   => 'root',
         group   => 'root',
         alias   => "sites-${name}",
-        notify  => Exec['reload-nginx'],
+        notify  => Service['nginx'],
         require => Package['nginx'],
       }
     }
@@ -26,7 +26,7 @@ define nginx::install_site($content=undef) {
         alias   => "sites-$name",
         content => $content,
         require => Package['nginx'],
-        notify  => Exec['reload-nginx'],
+        notify  => Service['nginx'],
       }
     }
   }
@@ -36,7 +36,7 @@ define nginx::install_site($content=undef) {
     unless  => "/bin/sh -c '[ -L /etc/nginx/sites-enabled/${name} ] && \
       [ /etc/nginx/sites-enabled/${name} -ef /etc/nginx/sites-available/${name} ]'",
     path    => ['/usr/bin/', '/bin/'],
-    notify  => Exec['reload-nginx'],
+    notify  => Service['nginx'],
     require => File["sites-${name}"],
   }
 }

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -18,7 +18,7 @@ define nginx::site($ensure='present', $content='') {
       exec { "/bin/rm -f /etc/nginx/sites-enabled/${name}":
         onlyif  => "/bin/sh -c '[ -L /etc/nginx/sites-enabled/${name} ] && \
           [ /etc/nginx/sites-enabled/$name -ef /etc/nginx/sites-available/${name} ]'",
-        notify  => Exec['reload-nginx'],
+        notify  => Service['nginx'],
         require => Package['nginx'],
       }
     }

--- a/manifests/site_include.pp
+++ b/manifests/site_include.pp
@@ -14,7 +14,7 @@ define nginx::site_include($ensure='present', $content='') {
     group   => 'root',
     content => $content,
     require => File[$nginx::nginx_includes],
-    notify  => Exec['reload-nginx'],
+    notify  => Service['nginx'],
   }
 }
 


### PR DESCRIPTION
I just think that it is more intuitive to write notify Service, than using an additionally defined Exec thingy. It is also on the road-map to really support Service with refresh option (http://projects.puppetlabs.com/issues/1014) right now, you can just set "restart    => '/etc/init.d/nginx reload'" and it does what you expect.
