### PR TITLE
Adds Fact for nginx Version

### DIFF
--- a/lib/facter/nginx.rb
+++ b/lib/facter/nginx.rb
@@ -1,14 +1,16 @@
-Facter.add(:nginxversion) do
-    setcode do
-        pattern = %r{^\d{1,}\.\d{1,}\.\d{1,}$}
-        unless defined?(@@nginxversion)
-            @@nginxversion = Facter::Util::Resolution.exec('nginx -v 2>&1 | cut -d "/" -f 2')
-        end
+{  "nginxversion"         => %r{^nginx version: nginx\/(\d{1,}\.\d{1,}\.\d{1,})$},
+}.each do |fact, pattern|
+    Facter.add(fact) do
+        setcode do
+            unless defined?(@@nginxversion)
+                @@nginxversion = Facter::Util::Resolution.exec('nginx -v 2>&1')
+            end
 
-        if pattern.match(@@nginxversion)
-            @@nginxversion
-        else
-            nil
+            if pattern.match(@@nginxversion)
+                $1
+            else
+                nil
+            end
         end
     end
 end

--- a/lib/facter/nginx.rb
+++ b/lib/facter/nginx.rb
@@ -1,0 +1,14 @@
+Facter.add(:nginxversion) do
+    setcode do
+        pattern = %r{^\d{1,}\.\d{1,}\.\d{1,}$}
+        unless defined?(@@nginxversion)
+            @@nginxversion = Facter::Util::Resolution.exec('nginx -v 2>&1 | cut -d "/" -f 2')
+        end
+
+        if pattern.match(@@nginxversion)
+            @@nginxversion
+        else
+            nil
+        end
+    end
+end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,7 +6,8 @@
 #
 # Parameters :
 # * ensure: typically set to "present" or "absent". Defaults to "present"
-# * content: set the content of the config snipppet. Defaults to 'template("nginx/${name}.conf.erb")'
+# * content: set the content of the config snipppet.
+#            Defaults to 'template("nginx/${name}.conf.erb")'
 # * order: specifies the load order for this config snippet. Defaults to "500"
 #
 define nginx::config($ensure='present', $content=undef, $order='500') {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,11 @@ class nginx {
   $nginx_includes = '/etc/nginx/includes'
   $nginx_conf = '/etc/nginx/conf.d'
 
+  $nginxversion = $nginxversion ? {
+    undef => '1.0.0',
+    default => $nginxversion
+  }
+
   $real_nginx_user = $::nginx_user ? {
     undef   => 'www-data',
     default => $::nginx_user

--- a/templates/nginx.conf.erb
+++ b/templates/nginx.conf.erb
@@ -10,6 +10,10 @@ events {
 }
 
 http {
+    <% if nginxversion =~ /^1\.\d{1,}\.\d{1,}$/ -%>
+    types_hash_max_size 2048;
+
+    <% end -%>
     include       /etc/nginx/mime.types;
 
     access_log	/var/log/nginx/access.log;


### PR DESCRIPTION
With the 1.0 release, the types_hash_max_size parameter is no more optional in nginx.conf - to determine nginx config version and fix this issue, I added a fact and used the nginxversion variable in nginx.conf to add the types_hash_max_size parameter.
