### PR TITLE
Update templates/fcgi_site.erb

### DIFF
--- a/templates/fcgi_site.erb
+++ b/templates/fcgi_site.erb
@@ -7,7 +7,7 @@ server {
 
 	root <%= root %>;
 
-<% if listen == '443' %>
+<% if ssl_certificate_key %>
         ssl  on;
         ssl_certificate  <%= real_ssl_certificate %>;
         ssl_certificate_key  <%= real_ssl_certificate_key %>;


### PR DESCRIPTION
Change the determining factor for deciding to use SSL.

This allows a user to put more than just the port into the listen directive.  eg:

   nginx::fcgi::site { 'default-ssl':
     listen          => '443 default_server',
     ...
   }

Later versions of nginx support this mode of configuration.

When using a wildcard SSL cert it is possible to have multiple domains on a single IP, so the 'default_server' switch is significant.  If running multiple sites on different IPs, then the user would want to set listen => 'example.com:443' which is also handled better with this change.
